### PR TITLE
Terminate client threads when PipeWire server shuts down

### DIFF
--- a/src/globals.h
+++ b/src/globals.h
@@ -11,6 +11,7 @@ extern "C" {
 /* extern globals */
 extern int run;
 extern int jack_reconnect;
+extern int shutdown;
 extern pthread_cond_t jack_trigger_cond;
 extern int daemonize;
 extern int verbosity;

--- a/src/jack_cpu_load.c
+++ b/src/jack_cpu_load.c
@@ -36,7 +36,7 @@ jack_client_t *client = NULL;
 void jack_shutdown (void *arg) {
 	pprintf (1, "jack-shutdown received.\n");
 	if (jack_reconnect) {
-		client=NULL;
+		shutdown=1;
 	} else {
 		run=0;
 	}

--- a/src/jackfreqd.c
+++ b/src/jackfreqd.c
@@ -121,7 +121,7 @@ int get_xdg_runtime_dir (char *pid, char *runtime_dir);
 #define PSTATE_MODE_POWERSAVE "powersave"
 #define PSTATE_MODE_PERFORMANCE "performance"
 
-#define VERSION	"0.1.3"
+#define VERSION	"0.2.2-1"
 
 void help(void) {
 

--- a/src/jackfreqd.c
+++ b/src/jackfreqd.c
@@ -81,6 +81,7 @@ typedef struct cpuinfo {
 cpuinfo_t **all_cpus;
 static char buf[1024];
 int run = 1;
+int shutdown = 0;
 
 /* options */
 int daemonize = 0;
@@ -1156,6 +1157,14 @@ int main (int argc, char **argv) {
 		}
 		pollts.tv_nsec = (pollts.tv_nsec + ((poll%1000)*1000000))%1000000000;
 		pthread_cond_timedwait(&jack_trigger_cond, &poll_wait_lock, &pollts);
+
+		if (jack_reconnect && shutdown) {
+			jjack_close();
+			/* force jjack_open() to call get_jack_uid() on server restart */
+			free(jack_uid);
+			jack_uid = NULL;
+			shutdown=0;
+		}
 
 		float jack_load = jjack_poll();
 		pprintf(4, "dsp load: %.3f\n", jack_load);

--- a/src/jackfreqd.c
+++ b/src/jackfreqd.c
@@ -768,7 +768,7 @@ void drop_privileges(char *setgid_group, char *setuid_user) {
 		char xdgDir[32];
 
 		if (get_xdg_runtime_dir(jack_pid, xdgDir))
-		  pprintf(0, "Couldn't get XDG_RUNTIME_DIR from /proc/%s/environ", jack_pid);
+		  pprintf(0, "Couldn't get XDG_RUNTIME_DIR from /proc/%s/environ\n", jack_pid);
 
 		if (setenv("XDG_RUNTIME_DIR", xdgDir, 1))
 		  pprintf(0, "Couldn't set XDG_RUNTIME_DIR=%s", xdgDir);

--- a/src/procps.c
+++ b/src/procps.c
@@ -277,7 +277,7 @@ int get_jack_proc (int *uid, int *gid, int *pid)
 
 int get_xdg_runtime_dir(char *pid, char *runtime_dir) {
 	char path[32];
-	char *buf;
+	char *buf = NULL;
 	FILE *fp;
 	int  offset = 0;
 	int  size;
@@ -299,7 +299,7 @@ int get_xdg_runtime_dir(char *pid, char *runtime_dir) {
 			offset += strlen(buf+offset) + 1;
 		}
 	}
-	free(buf);
+	if (buf) free(buf);
 	return 1;
 }
 


### PR DESCRIPTION
From the [JACK API documentation for `JackShutdownCallback`](https://jackaudio.org/api/types_8h.html#a1f461fe99711af7edcb1b73b1315fbb3):
> Note that after server shutdown, the client pointer is not deallocated by libjack, the application is responsible to properly use `jack_client_close()` to release client ressources. Warning: `jack_client_close()` cannot be safely used inside the shutdown callback and has to be called outside of the callback context.

Even though the API specification says it's the application's job to release client resources, when the server shuts down, `jackd` terminates the threads spawned by `jack_client_open()`. PipeWire, on the other hand, does not terminate the client threads automatically but expects the client to call `jack_client_close()` for that to happen. Currently, JackFreqD's old client threads are left running when PipeWire is restarted. This pull request fixes that behavior.

Due to the bug I mentioned in #6, I'm unable to test this using jack2 but the approach is what the API documentation recommends, so it should work. You may want to test for yourself with jack2 before merging to make sure I didn't overlook something.